### PR TITLE
Fix rake search path.

### DIFF
--- a/configure
+++ b/configure
@@ -3677,8 +3677,7 @@ else
   ;;
   *)
   as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-as_dummy="/usr/bin:/usr/local/bin"
-for as_dir in $as_dummy
+for as_dir in $PATH
 do
   IFS=$as_save_IFS
   test -z "$as_dir" && as_dir=.

--- a/configure.in
+++ b/configure.in
@@ -51,7 +51,7 @@ AS_ECHO(["--with-mruby: [$MRUBY_REPOS] will be used."])
 
 # Checks for rake or ruby
 AC_PATH_PROGS(RAKE_PATH, rake1.9.1 rake ruby1.9.1 ruby, no,
-        /usr/bin:/usr/local/bin)
+        $PATH)
 case $(basename "$RAKE_PATH") in
 ruby*)
         RAKE_PATH="$RAKE_PATH ./minirake" ;;


### PR DESCRIPTION
Find rake in $PATH because rake could be installed other than /usr/bin:/usr/local/bin especially in case of using rbenv.